### PR TITLE
EscapeOnHard - config support

### DIFF
--- a/EscapeOnHard/EscapeOnHardMod.cs
+++ b/EscapeOnHard/EscapeOnHardMod.cs
@@ -30,7 +30,7 @@ public class EscapeOnHardMod : MelonMod
         Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
 
         s_cfgCategoryMain = MelonPreferences.CreateCategory("EscapeOnHard");
-        s_cfgUseNormalEscapeOnHard = s_cfgCategoryMain.CreateEntry<bool>("UseNormalEscapeOnHard", false, "Use Normal difficulty escape rate in Hard difficulty.");
+        s_cfgUseNormalEscapeOnHard = s_cfgCategoryMain.CreateEntry<bool>("UseNormalEscapeOnHard", false, "Normal difficulty escape rate in Hard", description: "Use Normal difficulty escape rate in Hard difficulty");
         s_cfgLowerEscapeRateHardOnly = s_cfgCategoryMain.CreateEntry<bool>("LowerEscapeRateHardOnly", false, "Lower escape rate only in Hard", description: "Enables the lowers escape rate percentage only in hard mode.");
         s_cfgLowerEscapeRate = s_cfgCategoryMain.CreateEntry<float>("LowerEscapeRate", 0.0f, "Lower escape rate", description: "Lowers the vanilla escape rate. If the escape should work you get an bonus x% chance to fail the escape. 0% is vanilla escape rate, 100% is impossible to escape. Consider enabling UseNormalEscapeOnHard if you tweak this to keep reasonable escape odds.");
         s_cfgFastRetreatHigherRate = s_cfgCategoryMain.CreateEntry<float>("FastRetreatHigherRate", 0.0f, "Higher Fast Retreat escape rate", description: "Increase the odds of escaping with Fast Retreat. If the escape should fail, you get an additional x% percent chance to succeed escaping the battle. 100% makes the skill always work.");

--- a/EscapeOnHard/EscapeOnHardMod.cs
+++ b/EscapeOnHard/EscapeOnHardMod.cs
@@ -61,7 +61,7 @@ public class EscapeOnHardMod : MelonMod
         public static void Postfix(ref nbMainProcessData_t data, ref int __result)
         {
             // If Demi-fiend is the one escaping and he has Fast Retreat and he would fail the escape
-            if (data.activeunit == 0 && datCalc.datCheckSkillInParty(296) == 1 && __result == 0)
+            if (datCalc.datCheckSkillInParty(296) == 1 && __result == 0)
             {
                 bool escapedSecondRoll = MelonUtils.RandomDouble() * 100 <= (double)s_cfgFastRetreatHigherRate.Value;
                 __result = escapedSecondRoll ? 1 : 0;

--- a/EscapeOnHard/EscapeOnHardMod.cs
+++ b/EscapeOnHard/EscapeOnHardMod.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using Il2Cpp;
 using Il2Cppnewbattle_H;
 using MelonLoader;
+using MelonLoader.Utils;
 using Random = System.Random;
 
 [assembly: MelonInfo(typeof(EscapeOnHardMod), "Escape on Hard [low odds] (ver. 0.6)", "1.0.0", "Matthiew Purple")]
@@ -13,7 +14,28 @@ using Random = System.Random;
 namespace EscapeOnHard;
 public class EscapeOnHardMod : MelonMod
 {
+
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "EscapeOnHard.cfg");
+
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<float> s_cfgLowerEscapeRate = null!;
+    private static MelonPreferences_Entry<bool> s_cfgUseNormalEscapeOnHard = null!;
+    private static MelonPreferences_Entry<float> s_cfgFastRetreatHigherRate = null!;
+
     private static bool s_temporaryNormalMode = false; // Remembers if the game was on Hard difficulty before switching to Normal
+
+    public override void OnInitializeMelon()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("EscapeOnHard");
+        s_cfgUseNormalEscapeOnHard = s_cfgCategoryMain.CreateEntry<bool>("UseNormalEscapeOnHard", false, "Use Normal difficulty escape rate in Hard difficulty.");
+        s_cfgLowerEscapeRate = s_cfgCategoryMain.CreateEntry<float>("LowerEscapeRate", 0.0f, "Lower escape rate", description: "Lowers the vanilla escape rate. If the escape should work you get an bonus x% chance to fail the escape. 0% is vanilla escape rate, 100% is impossible to escape. Consider enabling UseNormalEscapeOnHard if you tweak this to keep reasonable escape odds.");
+        s_cfgFastRetreatHigherRate = s_cfgCategoryMain.CreateEntry<float>("FastRetreatHigherRate", 0.0f, "Higher Fast Retreat escape rate", description: "Increase the odds of escaping with Fast Retreat. If the escape should fail, you get an additional x% percent chance to succeed escaping the battle. 100% makes the skill always work.");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
+    }
 
     // Before checking if the player can escape
     [HarmonyPatch(typeof(nbCalc), nameof(nbCalc.nbCheckEscape))]
@@ -21,8 +43,8 @@ public class EscapeOnHardMod : MelonMod
     {
         public static void Prefix()
         {
-            // If the game is on Hard difficulty
-            if (dds3ConfigMain.cfgGetBit(9u) == 2)
+            // If the game is on Hard difficulty and we want to use normal difficulty escape rate
+            if (dds3ConfigMain.cfgGetBit(9u) == 2 && s_cfgUseNormalEscapeOnHard.Value)
             {
                 dds3ConfigMain.cfgSetBit(9u, 1); // Switches the game to Normal
                 s_temporaryNormalMode = true; // Remembers that it's only temporary
@@ -36,21 +58,23 @@ public class EscapeOnHardMod : MelonMod
     {
         public static void Postfix(ref nbMainProcessData_t data, ref int __result)
         {
-            // If Demi-fiend is the one escaping and he has Fast Retreat
-            if (data.activeunit == 0 && datCalc.datCheckSkillInParty(296) == 1)
+            // If Demi-fiend is the one escaping and he has Fast Retreat and he would fail the escape
+            if (data.activeunit == 0 && datCalc.datCheckSkillInParty(296) == 1 && __result == 0)
             {
-                __result = 1; // Always escape successfully
+                bool escapedSecondRoll = MelonUtils.RandomDouble() * 100 <= (double)s_cfgFastRetreatHigherRate.Value;
+                __result = escapedSecondRoll ? 1 : 0;
+            }
+
+            // If the escape is supposed to be successful then reroll with alternate probabilities
+            if (__result == 1)
+            {
+                bool escapedSecondRoll = MelonUtils.RandomDouble() * 100 <= (double)s_cfgLowerEscapeRate.Value;
+                __result = escapedSecondRoll ? 0 : 1;
             }
 
             // If on Normal mode temporarily
-            else if (s_temporaryNormalMode)
+            if (s_temporaryNormalMode)
             {
-                // If the escape is supposed to be successful then flip a coin
-                if (__result == 1)
-                {
-                    __result = new Random().Next(0, 2);
-                }
-
                 // Switches back to Hard mode
                 dds3ConfigMain.cfgSetBit(9u, 2);
             }

--- a/EscapeOnHard/EscapeOnHardMod.cs
+++ b/EscapeOnHard/EscapeOnHardMod.cs
@@ -18,8 +18,9 @@ public class EscapeOnHardMod : MelonMod
     public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "EscapeOnHard.cfg");
 
     private static MelonPreferences_Category s_cfgCategoryMain = null!;
-    private static MelonPreferences_Entry<float> s_cfgLowerEscapeRate = null!;
     private static MelonPreferences_Entry<bool> s_cfgUseNormalEscapeOnHard = null!;
+    private static MelonPreferences_Entry<float> s_cfgLowerEscapeRate = null!;
+    private static MelonPreferences_Entry<bool> s_cfgLowerEscapeRateHardOnly = null!;
     private static MelonPreferences_Entry<float> s_cfgFastRetreatHigherRate = null!;
 
     private static bool s_temporaryNormalMode = false; // Remembers if the game was on Hard difficulty before switching to Normal
@@ -30,6 +31,7 @@ public class EscapeOnHardMod : MelonMod
 
         s_cfgCategoryMain = MelonPreferences.CreateCategory("EscapeOnHard");
         s_cfgUseNormalEscapeOnHard = s_cfgCategoryMain.CreateEntry<bool>("UseNormalEscapeOnHard", false, "Use Normal difficulty escape rate in Hard difficulty.");
+        s_cfgLowerEscapeRateHardOnly = s_cfgCategoryMain.CreateEntry<bool>("LowerEscapeRateHardOnly", false, "Lower escape rate only in Hard", description: "Enables the lowers escape rate percentage only in hard mode.");
         s_cfgLowerEscapeRate = s_cfgCategoryMain.CreateEntry<float>("LowerEscapeRate", 0.0f, "Lower escape rate", description: "Lowers the vanilla escape rate. If the escape should work you get an bonus x% chance to fail the escape. 0% is vanilla escape rate, 100% is impossible to escape. Consider enabling UseNormalEscapeOnHard if you tweak this to keep reasonable escape odds.");
         s_cfgFastRetreatHigherRate = s_cfgCategoryMain.CreateEntry<float>("FastRetreatHigherRate", 0.0f, "Higher Fast Retreat escape rate", description: "Increase the odds of escaping with Fast Retreat. If the escape should fail, you get an additional x% percent chance to succeed escaping the battle. 100% makes the skill always work.");
 
@@ -66,7 +68,9 @@ public class EscapeOnHardMod : MelonMod
             }
 
             // If the escape is supposed to be successful then reroll with alternate probabilities
-            if (__result == 1)
+            // only if we want it to happen anytime, or if we want it to happen only in hard and we 
+            // are in temporary normal mode (=in hard the rest of the time)
+            if (__result == 1 && (!s_cfgLowerEscapeRateHardOnly.Value || s_temporaryNormalMode))
             {
                 bool escapedSecondRoll = MelonUtils.RandomDouble() * 100 <= (double)s_cfgLowerEscapeRate.Value;
                 __result = escapedSecondRoll ? 0 : 1;

--- a/README.md
+++ b/README.md
@@ -40,4 +40,3 @@ In bold, the only currently supported variant:
 - DisplayFutureSkills (**spoilers** / no spoilers)
 - ModernPressTurns (**SMT V** / SMT IV)
 - EveryoneGetsExp (**25%** / 50% / 75% / 100%)
-- EscapeOnHard (**low** / normal)


### PR DESCRIPTION
Adds config to EscapeOnHard. Should allow to reproduce the branches of the original mod (see proposed presets below).

# Config files
## Default (vanilla)
```toml
[EscapeOnHard]
# Use Normal difficulty escape rate in Hard difficulty
UseNormalEscapeOnHard = false
# Enables the lowers escape rate percentage only in hard mode.
LowerEscapeRateHardOnly = false
# Lowers the vanilla escape rate. If the escape should work you get an bonus x% chance to fail the escape. 0% is vanilla escape rate, 100% is impossible to escape. Consider enabling UseNormalEscapeOnHard if you tweak this to keep reasonable escape odds.
LowerEscapeRate = 0.0
# Increase the odds of escaping with Fast Retreat. If the escape should fail, you get an additional x% percent chance to succeed escaping the battle. 100% makes the skill always work.
FastRetreatHigherRate = 0.0
```

## Presets
### QoD Normal
```toml
[EscapeOnHard]
UseNormalEscapeOnHard = true
LowerEscapeRateHardOnly = false
LowerEscapeRate = 0.0
FastRetreatHigherRate = 100.0
```

### QoD Low
```toml
[EscapeOnHard]
UseNormalEscapeOnHard = true
LowerEscapeRateHardOnly = true
LowerEscapeRate = 50.0
FastRetreatHigherRate = 100.0
```