### PR TITLE
EveryoneGetsExp - config support

### DIFF
--- a/EveryoneGetsExp/EveryoneGetsExpMod.cs
+++ b/EveryoneGetsExp/EveryoneGetsExpMod.cs
@@ -52,7 +52,7 @@ public class EveryoneGetsExpMod : MelonMod
     {
         public static void Postfix()
         {
-            // Give passive demons either 25% or 100% exp if they have Watchful
+            // Give passive demons either s_cfgSharedXp% or s_cfgSharedXpWatchful% exp if they have Watchful
             for (int i = 0; i < dds3GlobalWork.DDS3_GBWK.unitwork.Length; i++)
             {
                 if (dds3GlobalWork.DDS3_GBWK.unitwork[i].hp > 0)
@@ -60,12 +60,12 @@ public class EveryoneGetsExpMod : MelonMod
                     // If a demon didn't get any exp yet (i.e. if it's a passive demon without Watchful)
                     if (s_unitExpList[i] == dds3GlobalWork.DDS3_GBWK.unitwork[i].exp)
                     {
-                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)(nbResultProcess.AllExp * s_cfgSharedXp.Value / 100)); // Get 25% exp
+                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)(nbResultProcess.AllExp * s_cfgSharedXp.Value / 100)); // Get s_cfgSharedXp%
                     }
                     // If they didn't get 100% exp and have Watchful
                     else if (s_unitExpList[i] + nbResultProcess.AllExp != dds3GlobalWork.DDS3_GBWK.unitwork[i].exp && dds3GlobalWork.DDS3_GBWK.unitwork[i].skill.Contains(354))
                     {
-                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)Math.Ceiling(nbResultProcess.AllExp * s_cfgSharedXpWatchful.Value / 100)); // Get 50% exp (+ vanilla 50% exp)
+                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)Math.Ceiling(nbResultProcess.AllExp * s_cfgSharedXpWatchful.Value / 100)); // Get s_cfgSharedXpWatchful% exp (+ vanilla 50% exp)
                     }
                 }
             }

--- a/EveryoneGetsExp/EveryoneGetsExpMod.cs
+++ b/EveryoneGetsExp/EveryoneGetsExpMod.cs
@@ -25,8 +25,8 @@ public class EveryoneGetsExpMod : MelonMod
         Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
 
         s_cfgCategoryMain = MelonPreferences.CreateCategory("EveryoneGetsExp");
-        s_cfgSharedXp = s_cfgCategoryMain.CreateEntry<float>("SharedXp", 50.0f, "Shared XP", description: "How much XP goes to the party members, in percents.");
-        s_cfgSharedXpWatchful = s_cfgCategoryMain.CreateEntry<float>("SharedXpWatchful", 50.0f, "Shared XP Watchful", description: "In addition to the default 50% XP given to the team members with Watchful, how much additional XP should they get, in percents.");
+        s_cfgSharedXp = s_cfgCategoryMain.CreateEntry<float>("SharedXp", 0.0f, "Shared XP", description: "How much XP goes to the party members, in percents.");
+        s_cfgSharedXpWatchful = s_cfgCategoryMain.CreateEntry<float>("SharedXpWatchful", 0.0f, "Shared XP Watchful", description: "In addition to the default 50% XP given to the team members with Watchful, how much additional XP should they get, in percents.");
 
         s_cfgCategoryMain.SetFilePath(ConfigPath);
         s_cfgCategoryMain.SaveToFile();

--- a/EveryoneGetsExp/EveryoneGetsExpMod.cs
+++ b/EveryoneGetsExp/EveryoneGetsExpMod.cs
@@ -11,7 +11,21 @@ using MelonLoader;
 namespace EveryoneGetsExp;
 public class EveryoneGetsExpMod : MelonMod
 {
+    public const string ConfigPath = "ModsCfg/EveryoneGetsExp.toml";
+
     private static uint[] s_unitExpList = Array.Empty<uint>();
+
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<float> s_cfgSharedXp = null!;
+    private static MelonPreferences_Entry<float> s_cfgSharedXpWatchful = null!;
+
+    public override void OnInitializeMelon()
+    {
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("EveryoneGetsExp");
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgSharedXp = s_cfgCategoryMain.CreateEntry<float>("SharedXp", 50.0f, "Shared XP", description: "How much XP goes to the party members, in percents.");
+        s_cfgSharedXpWatchful = s_cfgCategoryMain.CreateEntry<float>("SharedXpWatchful", 50.0f, "Shared XP Watchful", description: "In addition to the default 50% XP given to the team members with Watchful, how much additional XP should they get, in percents.");
+    }
 
     [HarmonyPatch(typeof(nbResultProcess), nameof(nbResultProcess.nbResultLoad))]
     private class Patch
@@ -41,12 +55,12 @@ public class EveryoneGetsExpMod : MelonMod
                     // If a demon didn't get any exp yet (i.e. if it's a passive demon without Watchful)
                     if (s_unitExpList[i] == dds3GlobalWork.DDS3_GBWK.unitwork[i].exp)
                     {
-                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)(nbResultProcess.AllExp * 0.25)); // Get 25% exp
+                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)(nbResultProcess.AllExp * s_cfgSharedXp.Value / 100)); // Get 25% exp
                     }
                     // If they didn't get 100% exp and have Watchful
                     else if (s_unitExpList[i] + nbResultProcess.AllExp != dds3GlobalWork.DDS3_GBWK.unitwork[i].exp && dds3GlobalWork.DDS3_GBWK.unitwork[i].skill.Contains(354))
                     {
-                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)Math.Ceiling(nbResultProcess.AllExp * 0.5)); // Get 50% exp (+ vanilla 50% exp)
+                        datCalc.datAddExp(dds3GlobalWork.DDS3_GBWK.unitwork[i], (int)Math.Ceiling(nbResultProcess.AllExp * s_cfgSharedXpWatchful.Value / 100)); // Get 50% exp (+ vanilla 50% exp)
                     }
                 }
             }
@@ -60,7 +74,7 @@ public class EveryoneGetsExpMod : MelonMod
         {
             if (id == 354)
             {
-                __result = "Earn 100% EXP when \nnot participating in battle."; // Overwrites Watchful's skill description
+                __result = $"Earn {50f + s_cfgSharedXpWatchful.Value}% EXP when \nnot participating in battle."; // Overwrites Watchful's skill description
             }
         }
     }

--- a/EveryoneGetsExp/EveryoneGetsExpMod.cs
+++ b/EveryoneGetsExp/EveryoneGetsExpMod.cs
@@ -4,6 +4,7 @@ using EveryoneGetsExp;
 using HarmonyLib;
 using Il2Cpp;
 using MelonLoader;
+using MelonLoader.Utils;
 
 [assembly: MelonInfo(typeof(EveryoneGetsExpMod), "Everyone Gets Experience 25% (0.6 ver.)", "1.0.0", "Matthiew Purple")]
 [assembly: MelonGame("アトラス", "smt3hd")]
@@ -11,7 +12,7 @@ using MelonLoader;
 namespace EveryoneGetsExp;
 public class EveryoneGetsExpMod : MelonMod
 {
-    public const string ConfigPath = "ModsCfg/EveryoneGetsExp.toml";
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "EveryoneGetsExp.cfg");
 
     private static uint[] s_unitExpList = Array.Empty<uint>();
 
@@ -21,10 +22,14 @@ public class EveryoneGetsExpMod : MelonMod
 
     public override void OnInitializeMelon()
     {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
         s_cfgCategoryMain = MelonPreferences.CreateCategory("EveryoneGetsExp");
-        s_cfgCategoryMain.SetFilePath(ConfigPath);
         s_cfgSharedXp = s_cfgCategoryMain.CreateEntry<float>("SharedXp", 50.0f, "Shared XP", description: "How much XP goes to the party members, in percents.");
         s_cfgSharedXpWatchful = s_cfgCategoryMain.CreateEntry<float>("SharedXpWatchful", 50.0f, "Shared XP Watchful", description: "In addition to the default 50% XP given to the team members with Watchful, how much additional XP should they get, in percents.");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
     }
 
     [HarmonyPatch(typeof(nbResultProcess), nameof(nbResultProcess.nbResultLoad))]

--- a/README.md
+++ b/README.md
@@ -39,5 +39,4 @@ In bold, the only currently supported variant:
 - OneMoreEnemyPressTurn (**all enemies** / bosses only / normal enemies only)
 - DisplayFutureSkills (**spoilers** / no spoilers)
 - ModernPressTurns (**SMT V** / SMT IV)
-- EveryoneGetsExp (**25%** / 50% / 75% / 100%)
 - EscapeOnHard (**low** / normal)


### PR DESCRIPTION
Adds config to EveryoneGetsExp. Should support allow to reproduce all the original mod presets/branches.

# Config
## Default (vanilla)
```toml
[EveryoneGetsExp]
# How much XP goes to the party members, in percents.
SharedXp = 0.0
# In addition to the default 50% XP given to the team members with Watchful, how much additional XP should they get, in percents.
SharedXpWatchful = 0.0
```

## Presets
### QoD 75%
```toml
[EveryoneGetsExp]
SharedXp = 75.0
SharedXpWatchful = 50.0
```
The other branches only change the SharedXp percentage to 25, 50 and 100. SharedXpWatchfull stays at 50%.