### PR TITLE
NormalPricesOnHard - config support

### DIFF
--- a/NormalPricesOnHard/NormalPricesOnHardMod.cs
+++ b/NormalPricesOnHard/NormalPricesOnHardMod.cs
@@ -3,6 +3,7 @@
 using HarmonyLib;
 using Il2Cpp;
 using MelonLoader;
+using MelonLoader.Utils;
 using NormalPricesOnHard;
 
 [assembly: MelonInfo(typeof(NormalPricesOnHardMod), "Normal prices on Hard (ver. 0.6)", "1.0.0", "Matthiew Purple")]
@@ -11,15 +12,43 @@ using NormalPricesOnHard;
 namespace NormalPricesOnHard;
 public class NormalPricesOnHardMod : MelonMod
 {
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "NormalPricesOnHard.cfg");
+
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<float> s_cfgPriceMultiplierNormal = null!;
+    private static MelonPreferences_Entry<float> s_cfgPriceMultiplierHard = null!;
+
+    public override void OnInitializeMelon()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("NormalPricesOnHard");
+        s_cfgPriceMultiplierNormal = s_cfgCategoryMain.CreateEntry<float>("PriceMultiplierNormal", 1.0f, "Price multiplier", description: "Items will cost their vanilla price multiplied by this value. (default: x1)");
+        s_cfgPriceMultiplierHard = s_cfgCategoryMain.CreateEntry<float>("PriceMultiplierHard", 3.0f, "Price multiplier (Hard difficulty)", description: "In hard difficulty, items will cost their vanilla price multiplied by this value. (default: x3)");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
+    }
+
     [HarmonyPatch(typeof(fclShopCalc), nameof(fclShopCalc.shpCalcItemPrice))]
     private class Patch
     {
         public static void Postfix(ref sbyte Mode, ref int __result)
         {
-            // If buying on Hard then multiply prices by 1/3
-            if (Mode == 0 && dds3ConfigMain.cfgGetBit(9u) == 2)
+            // If buying
+            if (Mode == 0)
             {
-                __result = __result / 3;
+                // then apply the multiplier,
+                // on Hard items costs three times as much, divide the price by three
+                if (dds3ConfigMain.cfgGetBit(9u) == 2)
+                {
+                    __result = (int)Math.Round(__result / 3 * s_cfgPriceMultiplierHard.Value);
+                }
+                // on normal / merciful (prices x1)
+                else
+                {
+                    __result = (int)Math.Round(__result * s_cfgPriceMultiplierNormal.Value);
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Everything else.
 In bold, the only currently supported variant:
 - BetterNewGamePlus (**magatama+items+demons+macca** / demons / items / macca / magatama / nothing)
 - PiercingMagmaAxis (**including repel** / no repel)
-- NormalPricesOnHard (**normal prices** / double prices)
 - FocusMagic (**standalone** / fixed focus compatible)
 - PierceWithoutTde (**80** / 90)
 - TruePierce (**phys including repel** / everything / phys+magic / phys+magic no repel)


### PR DESCRIPTION
Add config support for NormalPricesOnHard. Allows to reproduce all branches/presets of the original mod.

# Config files
## Default (vanilla)
```toml
[NormalPricesOnHard]
# Items will cost their vanilla price multiplied by this value. (default: x1)
PriceMultiplierNormal = 1.0
# In hard difficulty, items will cost their vanilla price multiplied by this value. (default: x3)
PriceMultiplierHard = 3.0
```

## Presets
### QoD normal prices
```toml
[NormalPricesOnHard]
PriceMultiplierNormal = 1.0
PriceMultiplierHard = 1.0
```

### QoD double prices
```toml
[NormalPricesOnHard]
PriceMultiplierNormal = 1.0
PriceMultiplierHard = 2.0
```