### PR TITLE
ModernPressTurn - config support

### DIFF
--- a/ModernPressTurns/ModernPressTurnsMod.cs
+++ b/ModernPressTurns/ModernPressTurnsMod.cs
@@ -3,6 +3,7 @@
 using HarmonyLib;
 using Il2Cpp;
 using MelonLoader;
+using MelonLoader.Utils;
 using ModernPressTurns;
 
 [assembly: MelonInfo(typeof(ModernPressTurnsMod), "Modern Press Turns [SMT V] (0.6 ver.)", "1.0.0", "Matthiew Purple")]
@@ -11,12 +12,42 @@ using ModernPressTurns;
 namespace ModernPressTurns;
 public class ModernPressTurnsMod : MelonMod
 {
-    // PASS
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "ModernPressTurns.cfg");
+
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<bool> s_cfgSmt5HalfPtBehaviour = null!;
+    private static MelonPreferences_Entry<bool> s_cfgPassCostsHalfPt = null!;
+    private static MelonPreferences_Entry<bool> s_cfgDismissCostsHalfPt = null!;
+    private static MelonPreferences_Entry<bool> s_cfgSummonCostsHalfPt = null!;
+    private static MelonPreferences_Entry<bool> s_cfgAnalyzeCostsHalfPt = null!;
+
+    public override void OnInitializeMelon()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("ModernPressTurns");
+        s_cfgSmt5HalfPtBehaviour = s_cfgCategoryMain.CreateEntry<bool>("Smt5HalfPtBehaviour", false, "SMTV Half press turns behaviour", description: "Use SMTV press turn behaviour : for half PT consumption, prioritize available full PTs and only consume press turns when there are none full available.");
+        s_cfgPassCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("PassCostsHalfPt", false, "Pass costs half a press turn", description: "Using Pass in combat consumes only a half press turn.");
+        s_cfgDismissCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("DismissCostsHalfPt", false, "Dismiss costs half a press turn", description: "Dismissing a demon in combat consumes only a half press turn.");
+        s_cfgSummonCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("SummonCostsHalfPt", false, "Summon costs half a press turn", description: "Summoning a demon in combat consumes only a half press turn.");
+        s_cfgAnalyzeCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("AnalyzeCostsHalfPt", false, "The Analyze skill costs half a press turn", description: "Using the Analyze skill consumes only a half press turn.");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
+    }
+
+    // PASS TURN
     [HarmonyPatch(typeof(nbActionProcess), nameof(nbActionProcess.SetAction_WAIT))]
     private class Patch
     {
         public static void Prefix()
         {
+            // Only proceed if the configuration requires it
+            if (!s_cfgPassCostsHalfPt.Value)
+            {
+                return;
+            }
+
             // If there are blinking press turns AND full press turns
             if (nbMainProcess.nbGetMainProcessData().press4_ten != nbMainProcess.nbGetMainProcessData().press4_p && nbMainProcess.nbGetMainProcessData().press4_p != 0)
             {
@@ -27,13 +58,19 @@ public class ModernPressTurnsMod : MelonMod
         }
     }
 
-    // DISMISS
+    // DISMISS DEMON
     [HarmonyPatch(typeof(nbActionProcess), nameof(nbActionProcess.SetAction_RETURN))]
     private class Patch2
     {
         public static void Postfix()
         {
-            // If there is at least one full press turn
+            // Only proceed if the configuration requires it
+            if (!s_cfgDismissCostsHalfPt.Value)
+            {
+                return;
+            }
+
+            // If there is at least one full press turn (if only blinking left, just apply vanilla behaviour)
             if (nbMainProcess.nbGetMainProcessData().press4_p != 0)
             {
                 // If there are no blinking press turns
@@ -45,7 +82,11 @@ public class ModernPressTurnsMod : MelonMod
                 // If there is at least one blinking press turn
                 else
                 {
-                    PressTurnsAdjustements.SecondaryFullToBlinking(); // Changes a secondary full press turn into a blinking press turn
+                    // And we want to have smt5 half press turn behaviour
+                    if (s_cfgSmt5HalfPtBehaviour.Value)
+                    {
+                        PressTurnsAdjustements.SecondaryFullToBlinking(); // Changes a secondary full press turn into a blinking press turn
+                    }
                 }
             }
 
@@ -53,12 +94,18 @@ public class ModernPressTurnsMod : MelonMod
         }
     }
 
-    // DISMISS (removes the 10 frames delay in press turn consumption for aesthetic reasons)
+    // DISMISS DEMON (removes the 10 frames delay in press turn consumption for aesthetic reasons)
     [HarmonyPatch(typeof(nbMakePacket), nameof(nbMakePacket.nbMakeNewPressPacket))]
     private class Patch22
     {
         public static void Prefix(ref int startframe, ref int ptype)
         {
+            // Only proceed if the configuration requires it
+            if (!s_cfgDismissCostsHalfPt.Value)
+            {
+                return;
+            }
+
             if (ptype == 9)
             {
                 startframe = 0; // If using DISMISS then create the PressPacket immediately
@@ -72,6 +119,12 @@ public class ModernPressTurnsMod : MelonMod
     {
         public static void Prefix()
         {
+            // Only proceed if the configuration requires it
+            if (!s_cfgSummonCostsHalfPt.Value)
+            {
+                return;
+            }
+
             // If there is at least one full press turn
             if (nbMainProcess.nbGetMainProcessData().press4_p != 0)
             {
@@ -84,7 +137,11 @@ public class ModernPressTurnsMod : MelonMod
                 // If there is at least one blinking press turn
                 else
                 {
-                    PressTurnsAdjustements.SecondaryFullToBlinking(); // Changes a secondary full press turn into a blinking press turn
+                    // And we want to have smt5 half press turn behaviour
+                    if (s_cfgSmt5HalfPtBehaviour.Value)
+                    {
+                        PressTurnsAdjustements.SecondaryFullToBlinking(); // Changes a secondary full press turn into a blinking press turn
+                    }
                 }
             }
 
@@ -98,6 +155,12 @@ public class ModernPressTurnsMod : MelonMod
     {
         public static void Postfix()
         {
+            // Only proceed if the configuration requires it
+            if (!s_cfgAnalyzeCostsHalfPt.Value)
+            {
+                return;
+            }
+
             // If there is at least one full press turn
             if (nbMainProcess.nbGetMainProcessData().press4_p != 0)
             {
@@ -108,6 +171,8 @@ public class ModernPressTurnsMod : MelonMod
 
     public static class PressTurnsAdjustements
     {
+        // p=full : number of full press turn
+        // ten=total : number of press turn left (INCLUDING half press turns)
         public static void MainFullToBlinking()
         {
             // The game automatically consumes the main full press turn

--- a/ModernPressTurns/ModernPressTurnsMod.cs
+++ b/ModernPressTurns/ModernPressTurnsMod.cs
@@ -16,7 +16,6 @@ public class ModernPressTurnsMod : MelonMod
 
     private static MelonPreferences_Category s_cfgCategoryMain = null!;
     private static MelonPreferences_Entry<bool> s_cfgSmt5HalfPtBehaviour = null!;
-    private static MelonPreferences_Entry<bool> s_cfgPassCostsHalfPt = null!;
     private static MelonPreferences_Entry<bool> s_cfgDismissCostsHalfPt = null!;
     private static MelonPreferences_Entry<bool> s_cfgSummonCostsHalfPt = null!;
     private static MelonPreferences_Entry<bool> s_cfgAnalyzeCostsHalfPt = null!;
@@ -27,7 +26,6 @@ public class ModernPressTurnsMod : MelonMod
 
         s_cfgCategoryMain = MelonPreferences.CreateCategory("ModernPressTurns");
         s_cfgSmt5HalfPtBehaviour = s_cfgCategoryMain.CreateEntry<bool>("Smt5HalfPtBehaviour", false, "SMTV Half press turns behaviour", description: "Use SMTV press turn behaviour : for half PT consumption, prioritize available full PTs and only consume press turns when there are none full available.");
-        s_cfgPassCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("PassCostsHalfPt", false, "Pass costs half a press turn", description: "Using Pass in combat consumes only a half press turn.");
         s_cfgDismissCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("DismissCostsHalfPt", false, "Dismiss costs half a press turn", description: "Dismissing a demon in combat consumes only a half press turn.");
         s_cfgSummonCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("SummonCostsHalfPt", false, "Summon costs half a press turn", description: "Summoning a demon in combat consumes only a half press turn.");
         s_cfgAnalyzeCostsHalfPt = s_cfgCategoryMain.CreateEntry<bool>("AnalyzeCostsHalfPt", false, "The Analyze skill costs half a press turn", description: "Using the Analyze skill consumes only a half press turn.");
@@ -43,7 +41,7 @@ public class ModernPressTurnsMod : MelonMod
         public static void Prefix()
         {
             // Only proceed if the configuration requires it
-            if (!s_cfgPassCostsHalfPt.Value)
+            if (!s_cfgSmt5HalfPtBehaviour.Value)
             {
                 return;
             }
@@ -164,7 +162,12 @@ public class ModernPressTurnsMod : MelonMod
             // If there is at least one full press turn
             if (nbMainProcess.nbGetMainProcessData().press4_p != 0)
             {
-                PressTurnsAdjustements.SecondaryFullToBlinking(); // Only this line is required as the game consumes the press turn AFTER this is called
+                // If no blinking pressturn (= if blinking, let the game consume it)
+                // OR if we want the SMT5-type half PT behaviour
+                if (nbMainProcess.nbGetMainProcessData().press4_p == nbMainProcess.nbGetMainProcessData().press4_ten || s_cfgSmt5HalfPtBehaviour.Value)
+                {
+                    PressTurnsAdjustements.SecondaryFullToBlinking(); // Only this line is required as the game consumes the press turn AFTER this is called
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,5 @@ In bold, the only currently supported variant:
 - TruePierce (**phys including repel** / everything / phys+magic / phys+magic no repel)
 - OneMoreEnemyPressTurn (**all enemies** / bosses only / normal enemies only)
 - DisplayFutureSkills (**spoilers** / no spoilers)
-- ModernPressTurns (**SMT V** / SMT IV)
 - EveryoneGetsExp (**25%** / 50% / 75% / 100%)
 - EscapeOnHard (**low** / normal)


### PR DESCRIPTION
Adds config support to ModernPressTurn. Allows to reproduce the original mod preset/branches (see presets below)

# Config files
## Default (vanilla)
```toml
[ModernPressTurns]
# Use SMTV press turn behaviour : for half PT consumption, prioritize available full PTs and only consume press turns when there are none full available.
Smt5HalfPtBehaviour = false
# Dismissing a demon in combat consumes only a half press turn.
DismissCostsHalfPt = false
# Summoning a demon in combat consumes only a half press turn.
SummonCostsHalfPt = false
# Using the Analyze skill consumes only a half press turn.
AnalyzeCostsHalfPt = false
```

## Presets
### QoD SMTV
```toml
[ModernPressTurns]
Smt5HalfPtBehaviour = true
DismissCostsHalfPt = true
SummonCostsHalfPt = true
AnalyzeCostsHalfPt = true
```

### QoD SMTIV
```toml
[ModernPressTurns]
Smt5HalfPtBehaviour = false
DismissCostsHalfPt = true
SummonCostsHalfPt = true
AnalyzeCostsHalfPt = true
```