### PR TITLE
OneMoreEnemyPressTurn - config support

### DIFF
--- a/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
+++ b/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
@@ -56,9 +56,9 @@ public class OneMoreEnemyPressTurnMod : MelonMod
             }
         }
     }
-    
+
     // List of enemies with an ID greater than 255 but that aren't bosses
-    private static readonly List<ushort> s_fakeBosses = new ()
+    private static readonly List<ushort> s_fakeBosses = new()
     {
         318, // Will o' Wisp (Tutorial)
         319, // Preta (Tutorial)

--- a/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
+++ b/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
@@ -2,7 +2,9 @@
 
 using HarmonyLib;
 using Il2Cpp;
+using Il2Cppnewdata_H;
 using MelonLoader;
+using MelonLoader.Utils;
 using OneMoreEnemyPressTurn;
 
 [assembly: MelonInfo(typeof(OneMoreEnemyPressTurnMod), "One more enemy Press Turn (ver. 0.6)", "1.0.0", "Matthiew Purple")]
@@ -11,6 +13,24 @@ using OneMoreEnemyPressTurn;
 namespace OneMoreEnemyPressTurn;
 public class OneMoreEnemyPressTurnMod : MelonMod
 {
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "OneMoreEnemyPressTurn.cfg");
+
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<int> s_cfgMorePressTurnRegularEnemies = null!;
+    private static MelonPreferences_Entry<int> s_cfgMorePressTurnBosses = null!;
+
+    public override void OnInitializeMelon()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("OneMoreEnemyPressTurn");
+        s_cfgMorePressTurnRegularEnemies = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnRegularEnemies", 0, "Additional press turn count (regular enemies)", description: "");
+        s_cfgMorePressTurnBosses = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnBosses", 0, "Additional press turn count (bosses)", description: "In hard difficulty, items will cost their vanilla price multiplied by this value. (default: x3)");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
+    }
+
     // After initiating a phase
     [HarmonyPatch(typeof(nbMainProcess), nameof(nbMainProcess.nbSetPressMaePhase))]
     private class Patch
@@ -18,13 +38,65 @@ public class OneMoreEnemyPressTurnMod : MelonMod
         public static void Postfix()
         {
             short activeunit = nbMainProcess.nbGetMainProcessData().activeunit; // Get the formindex of the first active demon
+            bool hasBoss = Utility.HasABossOnTheirSide();
 
             // If that demon is an enemy and the enemies don't already have 8 press turns
             if (activeunit >= 4 && nbMainProcess.nbGetMainProcessData().press4_p < 8)
             {
-                nbMainProcess.nbGetMainProcessData().press4_p++; // Add 1 full press turn
-                nbMainProcess.nbGetMainProcessData().press4_ten++; // Add 1 total press turn
+                if (hasBoss)
+                {
+                    nbMainProcess.nbGetMainProcessData().press4_p += (short)s_cfgMorePressTurnBosses.Value; // Add 1 full press turn
+                    nbMainProcess.nbGetMainProcessData().press4_ten += (short)s_cfgMorePressTurnBosses.Value; // Add 1 total press turn
+                }
+                else if (!hasBoss)
+                {
+                    nbMainProcess.nbGetMainProcessData().press4_p += (short)s_cfgMorePressTurnRegularEnemies.Value; // Add 1 full press turn
+                    nbMainProcess.nbGetMainProcessData().press4_ten += (short)s_cfgMorePressTurnRegularEnemies.Value; // Add 1 total press turn
+                }
             }
+        }
+    }
+    
+    // List of enemies with an ID greater than 255 but that aren't bosses
+    private static readonly List<ushort> s_fakeBosses = new ()
+    {
+        318, // Will o' Wisp (Tutorial)
+        319, // Preta (Tutorial)
+        260, // Incubus (Nihilo)
+        261, // Koppa Tengu (Nihilo)
+        359, // Virtue (White Rider)
+        360, // Power (Red Rider)
+        361, // Legion (Black Rider)
+        358, // Loa (Pale Rider)
+        279, // Urthona
+        280, // Urizen
+        281, // Luvah
+        282, // Tharmus
+        290, // Flauros Hallel
+        289  // Ose Hallel
+    };
+
+    private class Utility
+    {
+        // Checks if there is a boss on the enemy's side
+        public static bool HasABossOnTheirSide()
+        {
+            foreach (datUnitWork_t item in nbMainProcess.nbGetMainProcessData().enemyunit)
+            {
+                // If it's an actual boss (and not a mini-boss) who's still alive
+                if (item.id >= 256 && item.id < 362 && !s_fakeBosses.Contains(item.id) && item.hp != 0)
+                {
+                    return true;
+                }
+
+                // Special case for the Succubus chest boss
+                else if (item.id == 117 && nbMainProcess.nbGetMainProcessData().encno == 990)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
+++ b/OneMoreEnemyPressTurn/OneMoreEnemyPressTurnMod.cs
@@ -24,8 +24,8 @@ public class OneMoreEnemyPressTurnMod : MelonMod
         Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
 
         s_cfgCategoryMain = MelonPreferences.CreateCategory("OneMoreEnemyPressTurn");
-        s_cfgMorePressTurnRegularEnemies = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnRegularEnemies", 0, "Additional press turn count (regular enemies)", description: "");
-        s_cfgMorePressTurnBosses = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnBosses", 0, "Additional press turn count (bosses)", description: "In hard difficulty, items will cost their vanilla price multiplied by this value. (default: x3)");
+        s_cfgMorePressTurnRegularEnemies = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnRegularEnemies", 0, "Additional press turn count (regular enemies)", description: "Additional press turn count (regular enemies)");
+        s_cfgMorePressTurnBosses = s_cfgCategoryMain.CreateEntry<int>("MorePressTurnBosses", 0, "Additional press turn count (bosses)", description: "Additional press turn count (bosses)");
 
         s_cfgCategoryMain.SetFilePath(ConfigPath);
         s_cfgCategoryMain.SaveToFile();

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ In bold, the only currently supported variant:
 - FocusMagic (**standalone** / fixed focus compatible)
 - PierceWithoutTde (**80** / 90)
 - TruePierce (**phys including repel** / everything / phys+magic / phys+magic no repel)
-- OneMoreEnemyPressTurn (**all enemies** / bosses only / normal enemies only)
 - DisplayFutureSkills (**spoilers** / no spoilers)
 - ModernPressTurns (**SMT V** / SMT IV)
 - EveryoneGetsExp (**25%** / 50% / 75% / 100%)


### PR DESCRIPTION
Add config support to OneMoreEnemyPressTurn. Allows to reproduce all preset/branches from the original mod

# Config files
## Default (vanilla)
```toml
[OneMoreEnemyPressTurn]
# Additional press turn count (regular enemies)
MorePressTurnRegularEnemies = 0
# Additional press turn count (bosses)
MorePressTurnBosses = 0
```

## Presets
### QoD All enemies
```toml
[OneMoreEnemyPressTurn]
MorePressTurnRegularEnemies = 1
MorePressTurnBosses = 1
```

### QoD Regular enemies only
```toml
[OneMoreEnemyPressTurn]
MorePressTurnRegularEnemies = 1
MorePressTurnBosses = 0
```

### QoD Bosses only
```toml
[OneMoreEnemyPressTurn]
MorePressTurnRegularEnemies = 0
MorePressTurnBosses = 1
```