### PR TITLE
DisplayFutureSkills - config support

### DIFF
--- a/DisplayFutureSkills/DisplayFutureSkillsMod.cs
+++ b/DisplayFutureSkills/DisplayFutureSkillsMod.cs
@@ -6,6 +6,7 @@ using Il2Cpp;
 using Il2Cppnewdata_H;
 using Il2Cppresult2_H;
 using MelonLoader;
+using MelonLoader.Utils;
 
 [assembly: MelonInfo(typeof(DisplayFutureSkillsMod), "Display Future Skills (0.6 ver.)", "1.0.0", "Matthiew Purple")]
 [assembly: MelonGame("アトラス", "smt3hd")]
@@ -13,6 +14,21 @@ using MelonLoader;
 namespace DisplayFutureSkills;
 public class DisplayFutureSkillsMod : MelonMod
 {
+    public static readonly string ConfigPath = Path.Combine(MelonEnvironment.UserDataDirectory, "ModsCfg", "DisplayFutureSkills.cfg");
+    private static MelonPreferences_Category s_cfgCategoryMain = null!;
+    private static MelonPreferences_Entry<bool> s_cfgTease = null!;
+
+    public override void OnInitializeMelon()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+
+        s_cfgCategoryMain = MelonPreferences.CreateCategory("DisplayFutureSkills");
+        s_cfgTease = s_cfgCategoryMain.CreateEntry("TeaseDemifiendSkills", true, description: "Keeps some cool Demi-fiend skills as '?'.");
+
+        s_cfgCategoryMain.SetFilePath(ConfigPath);
+        s_cfgCategoryMain.SaveToFile();
+    }
+
     [HarmonyPatch(typeof(cmpDrawStatus), nameof(cmpDrawStatus.cmpDrawSkill))]
     private class Patch
     {
@@ -24,6 +40,17 @@ public class DisplayFutureSkillsMod : MelonMod
                 if (skillID == 0)
                 {
                     break;
+                }
+
+                if (s_cfgTease.Value && skillID == 357 && pStock.id == 0)
+                {
+                    // If you can get Pierce without TDE (mod) but aren't high level level enough
+                    if (EventBit.evtBitCheck(2241) && tblHearts.fclHeartsTbl[1].Skill[5].TargetLevel > pStock.level + 1)
+                    {
+                        cmpStatus._statusUIScr.awaitText[i].text = "<material=\"TMC14\">？"; // Displays a "？"
+                    }
+
+                    continue; //Skip Pierce on Demi-fiend
                 }
 
                 string name = datSkillName.Get(skillID, pStock.id);

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ In bold, the only currently supported variant:
 - PierceWithoutTde (**80** / 90)
 - TruePierce (**phys including repel** / everything / phys+magic / phys+magic no repel)
 - OneMoreEnemyPressTurn (**all enemies** / bosses only / normal enemies only)
-- DisplayFutureSkills (**spoilers** / no spoilers)
 - ModernPressTurns (**SMT V** / SMT IV)
 - EveryoneGetsExp (**25%** / 50% / 75% / 100%)
 - EscapeOnHard (**low** / normal)


### PR DESCRIPTION
Allows to reproduce spoiler/no spoiler variants.

# Config files
### QoD no spoilers (default)
```toml
[DisplayFutureSkills]
# Keeps some cool Demi-fiend skills as '?'.
TeaseDemifiendSkills = true
```

### QoD spoilers
```toml
[DisplayFutureSkills]
# Keeps some cool Demi-fiend skills as '?'.
TeaseDemifiendSkills = false
```